### PR TITLE
Missing bind env

### DIFF
--- a/MessageManager.class.nut
+++ b/MessageManager.class.nut
@@ -752,7 +752,7 @@ class MessageManager {
                         "id"   : payload["id"],
                         "data" : data
                     });
-                });
+                }.bindenv(this));
             }
         }
 


### PR DESCRIPTION
When replying to a message i was getting the error "index _partner does not exist" bindenv fixes that.