### PR TITLE
Tests fixed

### DIFF
--- a/tests/Base.nut
+++ b/tests/Base.nut
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright 2017 Electric Imp
+// Copyright 2017-2019 Electric Imp
 //
 // SPDX-License-Identifier: MIT
 //
@@ -101,8 +101,26 @@ class DummyConnectionManager {
     _onDisconnect = null;
     _onConnect = null;
 
+    static VERSION = "3.1.0";
+
     function constructor(settings = {}) {
         _connected = true;
+        
+        local startBehavior = ("startBehavior"   in settings) ? settings.startBehavior   : CM_START_NO_ACTION;
+
+        switch (startBehavior) {
+            case CM_START_NO_ACTION:
+                // Do nothing
+                break;
+            case CM_START_CONNECTED:
+                // Start connecting if they ask for it
+                imp.wakeup(0, connect.bindenv(this));
+                break;
+            case CM_START_DISCONNECTED:
+                // Disconnect if required
+                imp.wakeup(0, disconnect.bindenv(this));
+                break;
+        }
     }
 
     function isConnected() {
@@ -119,11 +137,11 @@ class DummyConnectionManager {
         _isFunc(_onConnect) && _onConnect();
     }
 
-    function onDisconnect(handler) {
+    function onDisconnect(handler, id) {
         _onDisconnect = handler;
     }
 
-    function onConnect(handler) {
+    function onConnect(handler, id) {
         _onConnect = handler;
     }
 

--- a/tests/EchoServer.nut
+++ b/tests/EchoServer.nut
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright 2017 Electric Imp
+// Copyright 2017-2019 Electric Imp
 //
 // SPDX-License-Identifier: MIT
 //
@@ -31,7 +31,7 @@
 
 local params = {};
 if (!isAgentSide()) {
-    params["connectionManager"] <- getConnectionManager();
+    params["connectionManager"] <- getConnectionManager(true, {"startBehavior": CM_START_CONNECTED});
 }
 params["onPartnerConnected"] <- function(reply) {
     reply(REPLY_NO_MESSAGES);

--- a/tests/compatibility/agent2device/ConnectionRealTestCase.agent.test.nut
+++ b/tests/compatibility/agent2device/ConnectionRealTestCase.agent.test.nut
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright 2017 Electric Imp
+// Copyright 2017-2019 Electric Imp
 //
 // SPDX-License-Identifier: MIT
 //
@@ -47,7 +47,7 @@ class ConnectionRealTestCase extends ImpTestCase {
                 "nextIdGenerator":    msgIdGenerator,
                 "onPartnerConnected": onPartnerConnected.bindenv(this)
             });
-            imp.wakeup(2, function() {
+            imp.wakeup(5, function() {
                 try {
                     assertTrue(partnerConnected, "Partner is not connected");
                     resolve();

--- a/tests/compatibility/agent2device/ConnectionRealTestCase.device.nut
+++ b/tests/compatibility/agent2device/ConnectionRealTestCase.device.nut
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright 2017 Electric Imp
+// Copyright 2017-2019 Electric Imp
 //
 // SPDX-License-Identifier: MIT
 //
@@ -27,7 +27,7 @@
 @include __PATH__+"/../../Base.nut"
 
 local mm = MessageManager({
-    "connectionManager": getConnectionManager(false),
+    "connectionManager": getConnectionManager(false, {"startBehavior": CM_START_CONNECTED}),
     "onPartnerConnected": function(reply) {
         reply(REPLY_NO_MESSAGES);
     }.bindenv(this)

--- a/tests/compatibility/agent2device/ConnectionTestCase.agent.test.nut
+++ b/tests/compatibility/agent2device/ConnectionTestCase.agent.test.nut
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright 2017 Electric Imp
+// Copyright 2017-2019 Electric Imp
 //
 // SPDX-License-Identifier: MIT
 //
@@ -47,7 +47,7 @@ class ConnectionTestCase extends ImpTestCase {
                 "nextIdGenerator":    msgIdGenerator,
                 "onPartnerConnected": onPartnerConnected.bindenv(this),
             });
-            imp.wakeup(2, function() {
+            imp.wakeup(5, function() {
                 try {
                     assertTrue(partnerConnected, "Partner is not connected");
                     resolve();

--- a/tests/compatibility/agent2device/ConnectionTestCase.device.nut
+++ b/tests/compatibility/agent2device/ConnectionTestCase.device.nut
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright 2017 Electric Imp
+// Copyright 2017-2019 Electric Imp
 //
 // SPDX-License-Identifier: MIT
 //
@@ -27,7 +27,7 @@
 @include __PATH__+"/../../Base.nut"
 
 local mm = MessageManager({
-    "connectionManager": getConnectionManager(true),
+    "connectionManager": getConnectionManager(true, {"startBehavior": CM_START_CONNECTED}),
     "onPartnerConnected": function(reply) {
         reply(REPLY_NO_MESSAGES);
     }.bindenv(this)

--- a/tests/compatibility/device2agent/ConnectionRealTestCase.device.test.nut
+++ b/tests/compatibility/device2agent/ConnectionRealTestCase.device.test.nut
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright 2017 Electric Imp
+// Copyright 2017-2019 Electric Imp
 //
 // SPDX-License-Identifier: MIT
 //
@@ -44,7 +44,7 @@ class ConnectionRealTestCase extends ImpTestCase {
             local mm = MessageManager({
                 "firstMessageId":     msgId,
                 "nextIdGenerator":    msgIdGenerator,
-                "connectionManager":  getConnectionManager(false),
+                "connectionManager":  getConnectionManager(false, {"startBehavior": CM_START_CONNECTED}),
                 "onConnectedReply":   onConnectedReply.bindenv(this)
             });
             imp.wakeup(2, function() {

--- a/tests/compatibility/device2agent/ConnectionTestCase.device.test.nut
+++ b/tests/compatibility/device2agent/ConnectionTestCase.device.test.nut
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright 2017 Electric Imp
+// Copyright 2017-2019 Electric Imp
 //
 // SPDX-License-Identifier: MIT
 //
@@ -44,7 +44,7 @@ class ConnectionRealTestCase extends ImpTestCase {
             local mm = MessageManager({
                 "firstMessageId":     msgId,
                 "nextIdGenerator":    msgIdGenerator,
-                "connectionManager":  getConnectionManager(true),
+                "connectionManager":  getConnectionManager(true, {"startBehavior": CM_START_CONNECTED}),
                 "onConnectedReply":   onConnectedReply.bindenv(this)
             });
             imp.wakeup(2, function() {


### PR DESCRIPTION
Some tests fixed, which were broken due ConnectionManager update.
1. Add VERSION in DummyConnectionManager to make one CM v3.1.0 compatible. 
2. Add startBehavior support in DummyConnectionManager to make one CM v3.1.0 compatible. 
3. Increased check message recieve timeout to make test passing more stable.